### PR TITLE
feat(tracking): add DTOs and validation dependency for robot tracking module

### DIFF
--- a/robotControl/build.gradle
+++ b/robotControl/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation' 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/CurrentLocationResponse.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/CurrentLocationResponse.java
@@ -1,0 +1,12 @@
+package com.laioffer.robotcontrol.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record CurrentLocationResponse(
+        @NotBlank String deviceId,
+        @NotNull LocationDTO location,
+        @NotNull TrackingStatus status,
+        @NotNull Instant timestamp
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/DeviceInfoResponse.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/DeviceInfoResponse.java
@@ -1,0 +1,19 @@
+package com.laioffer.robotcontrol.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record DeviceInfoResponse(
+        @NotBlank String deviceId,
+        @NotNull DeviceType deviceType,       // "robot" / "drone"
+        @NotNull TrackingStatus status,       // tracking 运行时态
+        @DecimalMin("0.0") Double availableDistanceKm,  // 等价续航；tracking.doc 中的 available_distance
+        String routeId,
+        String currentStation,                // 站点名称或ID（与 Station Management 对齐）
+        @Min(0) @Max(100) Integer batteryLevel, // 若来自站点模块device表，可带上电量补充信息
+        Instant startingTime                  // 任务开始时间
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/DeviceType.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/DeviceType.java
@@ -1,0 +1,14 @@
+package com.laioffer.robotcontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum DeviceType {
+    ROBOT("robot"),
+    DRONE("drone");
+
+    private final String value;
+    DeviceType(String v) { this.value = v; }
+
+    @JsonValue
+    public String getValue() { return value; }
+}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/LocationDTO.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/LocationDTO.java
@@ -1,0 +1,18 @@
+package com.laioffer.robotcontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+public record LocationDTO(
+        @NotNull
+        @DecimalMin("-90.0") @DecimalMax("90.0")
+        @JsonAlias({"lat", "latitude"})
+        Double latitude,
+
+        @NotNull
+        @DecimalMin("-180.0") @DecimalMax("180.0")
+        @JsonAlias({"lng", "lon", "longitude"})
+        Double longitude
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/ModifyRouteRequest.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/ModifyRouteRequest.java
@@ -1,0 +1,10 @@
+package com.laioffer.robotcontrol.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ModifyRouteRequest(
+        @NotNull RouteDTO newRoute,
+        @NotBlank String routeId,
+        @NotNull TrackingStatus status  // "in_transit" / "pending"（到站或送货途中）
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/ModifyRouteResponse.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/ModifyRouteResponse.java
@@ -1,0 +1,6 @@
+package com.laioffer.robotcontrol.dto;
+
+public record ModifyRouteResponse(
+        boolean success,
+        String message
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/RemainingTimeResponse.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/RemainingTimeResponse.java
@@ -1,0 +1,9 @@
+package com.laioffer.robotcontrol.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record RemainingTimeResponse(
+        @NotBlank String deviceId,
+        @Min(0) long remainingTimeSec
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/RouteDTO.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/RouteDTO.java
@@ -1,0 +1,13 @@
+package com.laioffer.robotcontrol.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+
+/** 简化版路线描述；与 routeplanning 的 polyline 思路一致 */
+public record RouteDTO(
+        @NotEmpty List<LocationDTO> polyline,
+        @NotNull Instant generatedAt,   // 生成时间（ISO8601）
+        String source                   // 可选："ROUTING_SERVICE" 等
+) {}

--- a/robotControl/src/main/java/com/laioffer/robotcontrol/dto/TrackingStatus.java
+++ b/robotControl/src/main/java/com/laioffer/robotcontrol/dto/TrackingStatus.java
@@ -1,0 +1,17 @@
+package com.laioffer.robotcontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** 仅 tracking 用到的运行态；若要与站点可派发态(available/in_use/locked/maintenance)映射，可在 service 层转换 */
+public enum TrackingStatus {
+    PENDING("pending"),
+    IN_TRANSIT("in_transit"),
+    ARRIVED("arrived"),
+    CANCELLED("cancelled");
+
+    private final String value;
+    TrackingStatus(String v) { this.value = v; }
+
+    @JsonValue
+    public String getValue() { return value; }
+}


### PR DESCRIPTION
This PR adds Data Transfer Objects (DTOs) for the Tracking (robotControl) module.
These DTOs define standardized request and response formats for the four main tracking APIs.
Also added the spring-boot-starter-validation dependency for jakarta.validation support.